### PR TITLE
Failure in windows conda environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
          'numpy==1.14.5', 'subprocess32==3.5.2', 'scipy==1.1.0'],
-    package_dir={'quanttb': 'quanttb/'},
+    package_dir={'quanttb': 'quanttb'},
     package_data={'quanttb': ['data/*']},
     #include_package_data = True,
     #scripts=['scripts/classify.py', 'scripts/runnucmer.py', 'scripts/quanttb.py'],


### PR DESCRIPTION
Removing trailing / is required to get the install to work on windows.